### PR TITLE
Fixed a bug and added macro f1 support with cli commands for it

### DIFF
--- a/src/model/module/bilstm_encoder.py
+++ b/src/model/module/bilstm_encoder.py
@@ -37,7 +37,7 @@ class BiLSTMEncoder(nn.Module):
         _, recover_idx = permIdx.sort(0, descending=False)
         sorted_seq_tensor = word_rep[permIdx]
 
-        packed_words = pack_padded_sequence(sorted_seq_tensor, sorted_seq_len, True)
+        packed_words = pack_padded_sequence(sorted_seq_tensor, sorted_seq_len.cpu(), True)
         lstm_out, _ = self.lstm(packed_words, None)
         lstm_out, _ = pad_packed_sequence(lstm_out, batch_first=True)  ## CARE: make sure here is batch_first, otherwise need to transpose.
         feature_out = self.drop_lstm(lstm_out)

--- a/transformers_trainer.py
+++ b/transformers_trainer.py
@@ -62,6 +62,7 @@ def parse_arguments(parser):
     parser.add_argument('--add_iobes_constraint', type=int, default=0, choices=[0,1], help="add IOBES constraint for transition parameters to enforce valid transitions")
 
     parser.add_argument("--print_detail_f1", type= int, default= 0, choices= [0, 1], help= "Open and close printing f1 scores for each tag after each evaluation epoch")
+    parser.add_argument("--earlystop_atr", type=str, default="micro", choices= ["micro", "macro"], help= "Choose between macro f1 score and micro f1 score for early stopping evaluation")
 
     parser.add_argument('--mode', type=str, default="train", choices=["train", "test"], help="training model or test mode")
     parser.add_argument('--test_file', type=str, default="data/conll2003_sample/test.txt", help="test file for test mode, only applicable in test mode")
@@ -182,7 +183,7 @@ def evaluate_model(config: Config, model: TransformersCRF, data_loader: DataLoad
             total_entity_dict += batch_total
             batch_id += 1
     f1Scores = []
-    if print_each_type_metric or config.print_detail_f1:
+    if print_each_type_metric or config.print_detail_f1 or (config.earlystop_atr == "macro"):
         for key in total_entity_dict:
             precision_key, recall_key, fscore_key = get_metric(p_dict[key], total_entity_dict[key], total_predict_dict[key])
             print(f"[{key}] Prec.: {precision_key:.2f}, Rec.: {recall_key:.2f}, F1: {fscore_key:.2f}")
@@ -194,8 +195,10 @@ def evaluate_model(config: Config, model: TransformersCRF, data_loader: DataLoad
     total_predict = sum(list(total_predict_dict.values()))
     total_entity = sum(list(total_entity_dict.values()))
     precision, recall, fscore = get_metric(total_p, total_entity, total_predict)
-    print(colored(f"[{name} set Total] Prec.: {precision:.2f}, Rec.: {recall:.2f}, F1: {fscore:.2f}", 'blue'), flush=True)
+    print(colored(f"[{name} set Total] Prec.: {precision:.2f}, Rec.: {recall:.2f}, Micro F1: {fscore:.2f}", 'blue'), flush=True)
 
+    if config.earlystop_atr == "macro" and len(f1Scores) > 0:
+        fscore = sum(f1Scores) / len(f1Scores)
 
     return [precision, recall, fscore]
 

--- a/transformers_trainer.py
+++ b/transformers_trainer.py
@@ -61,6 +61,8 @@ def parse_arguments(parser):
                         help="use parallel training for those (BERT) models in the transformers. Parallel on GPUs")
     parser.add_argument('--add_iobes_constraint', type=int, default=0, choices=[0,1], help="add IOBES constraint for transition parameters to enforce valid transitions")
 
+    parser.add_argument("--print_detail_f1", type= int, default= 0, choices= [0, 1], help= "Open and close printing f1 scores for each tag after each evaluation epoch")
+
     parser.add_argument('--mode', type=str, default="train", choices=["train", "test"], help="training model or test mode")
     parser.add_argument('--test_file', type=str, default="data/conll2003_sample/test.txt", help="test file for test mode, only applicable in test mode")
 
@@ -179,10 +181,14 @@ def evaluate_model(config: Config, model: TransformersCRF, data_loader: DataLoad
             total_predict_dict += batch_predict
             total_entity_dict += batch_total
             batch_id += 1
-    if print_each_type_metric:
+    f1Scores = []
+    if print_each_type_metric or config.print_detail_f1:
         for key in total_entity_dict:
             precision_key, recall_key, fscore_key = get_metric(p_dict[key], total_entity_dict[key], total_predict_dict[key])
             print(f"[{key}] Prec.: {precision_key:.2f}, Rec.: {recall_key:.2f}, F1: {fscore_key:.2f}")
+            f1Scores.append(fscore_key)
+        if len(f1Scores) > 0:
+            print(f"[{name} set Total] Macro F1: {sum(f1Scores) / len(f1Scores):.2f}")
 
     total_p = sum(list(p_dict.values()))
     total_predict = sum(list(total_predict_dict.values()))


### PR DESCRIPTION
1- bilstm_encoder had an issue with the sorted_seq_len where if code runs on a gpu, pytorch throws an error since seq_len is also on gpu and should be on cpu instead.
2- Base code has the feature of printing f1 score of each tag but there is no mention of it in cli arguments, I added one and connected it to actual code
3- I added support for changing early stopping monitor between micro f1 and macro f1, which can be useful for tasks with inherent imbalance of tags. This is also a quite common case.